### PR TITLE
Update base64.h to set base64 linesize to 20000

### DIFF
--- a/include/xmlsec/base64.h
+++ b/include/xmlsec/base64.h
@@ -25,7 +25,7 @@ extern "C" {
  *
  * The default maximum base64 encoded line size.
  */
-#define XMLSEC_BASE64_LINESIZE                          64
+#define XMLSEC_BASE64_LINESIZE                          20000
 
 XMLSEC_EXPORT int               xmlSecBase64GetDefaultLineSize  (void);
 XMLSEC_EXPORT void              xmlSecBase64SetDefaultLineSize  (int columns);


### PR DESCRIPTION
We cannot have line endings in our signed xml and thus need the line size to be artificially high to prevent this.