### PR TITLE
Update ycharts_patch_tag.yml

### DIFF
--- a/.github/workflows/ycharts_patch_tag.yml
+++ b/.github/workflows/ycharts_patch_tag.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   sync_with_upstream:
-      runs-on: namespace-profile-ubuntu-2004-4vcpu-8gbram
+      runs-on: namespace-profile-ubuntu-2204-4vcpu-8gbram
       steps:
       - name: Checkout repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Updates Ubuntu to 22.04 ahead of 20.04 End of Life on May 31, 2025.